### PR TITLE
Ran this script on original hardware; proposed additions

### DIFF
--- a/itg-installer.sh
+++ b/itg-installer.sh
@@ -22,6 +22,7 @@ kernel_module(){
 	echo -e "a newer driver be required.\n";
 	echo -e "Working Examples: GeForce 9400    ${GREEN}(331.49)${NC}";
 	echo -e "                  GeForce GT 630  ${GREEN}(340.64)${NC}\n";
+	echo -e "                  GeForce FX 5200  ${GREEN}(173.14)${NC}\n";
 }
 
 nvidia_choice(){
@@ -44,9 +45,8 @@ nvidia_173_14(){
 	else
 		echo "Downloading NVIDIA Driver";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86/173.14.39/NVIDIA-Linux-x86-173.14.39-pkg1.run" -P /home/itg/;
-		chmod 777 /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
 		chmod +x /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
-                /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
+                ./home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
 	fi
 }
 
@@ -58,7 +58,6 @@ nvidia_331_49(){
 	else
 		echo "Downloading NVIDIA Driver";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/331.49/NVIDIA-Linux-x86_64-331.49.run" -P /home/itg/;	
-                chmod +x /home/itg/NVIDIA-Linux-x86_64-331.49.run
 		/home/itg/NVIDIA-Linux-x86_64-331.49.run -a -X -q
 	fi
 }
@@ -72,7 +71,6 @@ nvidia_340_65(){
 	else
 		echo "Downloading NVIDIA Driver then intalling";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/340.65/NVIDIA-Linux-x86_64-340.65.run" -P /home/itg/;
-		chmod +x /home/itg/NVIDIA-Linux-x86_64-340.65.run
 		/home/itg/NVIDIA-Linux-x86_64-340.65.run -a -X -q
 	fi
 }
@@ -85,7 +83,6 @@ nvidia_340_96(){
 	else
 		echo "Downloading NVIDIA Driver then installing";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/340.96/NVIDIA-Linux-x86_64-340.96.run" -P /home/itg/;
-		chmod +x /home/itg/NVIDIA-Linux-x86_64-340.96.run
 		/home/itg/NVIDIA-Linux-x86_64-340.96.run -a -X -q
 	fi
 }

--- a/itg-installer.sh
+++ b/itg-installer.sh
@@ -25,14 +25,28 @@ kernel_module(){
 }
 
 nvidia_choice(){
-	read -p "Which Nvidia driver would you like to install (331_49/340_65/340_96)? " choice
+	read -p "Which Nvidia driver would you like to install (173_14/331_49/340_65/340_96)? " choice
 
 	case "$choice" in
+	  173_14 ) nvidia_173_14 ;;	
 	  331_49 ) nvidia_331_49 ;;
 	  340_65 ) nvidia_340_65 ;;
 	  340_96 ) nvidia_340_96 ;;
 	  *   ) echo "${RED}Invalid Choice${NC}"; nvidia_choice ;;
 	esac
+}
+
+nvidia_173_14(){
+	if [ -f "/home/itg/drivers/NVIDIA-Linux-x86-173.14.39-pkg1.run" ]
+	then
+		echo "Installing NVIDIA-Linux-x86-173.14.39-pkg1.run";
+		/home/itg/drivers/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
+	else
+		echo "Downloading NVIDIA Driver";
+		wget "http://us.download.nvidia.com/XFree86/Linux-x86/173.14.39/NVIDIA-Linux-x86-173.14.39-pkg1.run" -P /home/itg/;	
+				chmod +x /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
+                /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
+	fi
 }
 
 nvidia_331_49(){
@@ -43,7 +57,8 @@ nvidia_331_49(){
 	else
 		echo "Downloading NVIDIA Driver";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/331.49/NVIDIA-Linux-x86_64-331.49.run" -P /home/itg/;	
-                /home/itg/NVIDIA-Linux-x86_64-331.49.run -a -X -q
+                chmod +x /home/itg/NVIDIA-Linux-x86_64-331.49.run
+				/home/itg/NVIDIA-Linux-x86_64-331.49.run -a -X -q
 	fi
 }
 
@@ -56,6 +71,7 @@ nvidia_340_65(){
 	else
 		echo "Downloading NVIDIA Driver then intalling";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/340.65/NVIDIA-Linux-x86_64-340.65.run" -P /home/itg/;
+		chmod +x /home/itg/NVIDIA-Linux-x86_64-340.65.run
 		/home/itg/NVIDIA-Linux-x86_64-340.65.run -a -X -q
 	fi
 }
@@ -68,6 +84,7 @@ nvidia_340_96(){
 	else
 		echo "Downloading NVIDIA Driver then installing";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/340.96/NVIDIA-Linux-x86_64-340.96.run" -P /home/itg/;
+		chmod +x /home/itg/NVIDIA-Linux-x86_64-340.96.run
 		/home/itg/NVIDIA-Linux-x86_64-340.96.run -a -X -q
 	fi
 }
@@ -154,10 +171,19 @@ internet_check(){
 install_packages(){
 	#Install required packages
 	apt-get update
-	apt-get install -y build-essential libc6-i386 libx11-6:i386 libglu1-mesa:i386 \
-	libpng12-0:i386 libjpeg62:i386 libusb-0.1-4:i386 libxrandr2:i386 libstdc++5:i386 \
-	alsa xinit x11-xserver-utils libXtst6:i386 libasound2:i386 pmount zip unzip \
-	libusb-0.1-4:i386 xinit;
+	if [ `getconf LONG_BIT` = "64" ]
+	then
+		apt-get install -y build-essential libc6-i386 libx11-6:i386 libglu1-mesa:i386 \
+		libpng12-0:i386 libjpeg62:i386 libusb-0.1-4:i386 libxrandr2:i386 libstdc++5:i386 \
+		alsa xinit x11-xserver-utils libXtst6:i386 libasound2:i386 pmount zip unzip \
+		libusb-0.1-4:i386 xinit;
+	else
+		apt-get install -y build-essential libx11-6 libglu1-mesa \
+		libpng12-0 libjpeg62 libusb-0.1-4 libxrandr2 libstdc++5 \
+		alsa xinit x11-xserver-utils libXtst6 libasound2 pmount zip unzip \
+		libusb-0.1-4 xinit;
+fi
+
 }
 
 cab_config(){

--- a/itg-installer.sh
+++ b/itg-installer.sh
@@ -43,8 +43,9 @@ nvidia_173_14(){
 		/home/itg/drivers/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
 	else
 		echo "Downloading NVIDIA Driver";
-		wget "http://us.download.nvidia.com/XFree86/Linux-x86/173.14.39/NVIDIA-Linux-x86-173.14.39-pkg1.run" -P /home/itg/;	
-				chmod +x /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
+		wget "http://us.download.nvidia.com/XFree86/Linux-x86/173.14.39/NVIDIA-Linux-x86-173.14.39-pkg1.run" -P /home/itg/;
+		chmod 777 /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
+		chmod +x /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run
                 /home/itg/NVIDIA-Linux-x86-173.14.39-pkg1.run -a -X -q
 	fi
 }
@@ -58,7 +59,7 @@ nvidia_331_49(){
 		echo "Downloading NVIDIA Driver";
 		wget "http://us.download.nvidia.com/XFree86/Linux-x86_64/331.49/NVIDIA-Linux-x86_64-331.49.run" -P /home/itg/;	
                 chmod +x /home/itg/NVIDIA-Linux-x86_64-331.49.run
-				/home/itg/NVIDIA-Linux-x86_64-331.49.run -a -X -q
+		/home/itg/NVIDIA-Linux-x86_64-331.49.run -a -X -q
 	fi
 }
 


### PR DESCRIPTION
The problem with BoXors isn't really the hardware, but the software. I modified the script to run on original HW for people who want to keep the original HDD and set up a dual-boot configuration.

I can attest that a simple software overhaul made the loading times on my machine MUCH better.

**173 driver does not work on Kernel 3.13, I had to use Ubuntu Server 12.04.1 (3.20)** And i386 of course.
